### PR TITLE
Fix native string marshaling double free on Linux

### DIFF
--- a/SWIG/storj_uplink_second.i
+++ b/SWIG/storj_uplink_second.i
@@ -70,13 +70,17 @@ MAP_SPECIAL(_Bool, bool, _Bool)
             }
         }
 
-	public static string StringFromNativeUtf8(System.IntPtr nativeUtf8)
+        public static string StringFromNativeUtf8(System.IntPtr nativeUtf8)
         {
+            if (nativeUtf8 == System.IntPtr.Zero)
+            {
+                return null;
+            }
+
             int len = 0;
             while (System.Runtime.InteropServices.Marshal.ReadByte(nativeUtf8, len) != 0) ++len;
             byte[] buffer = new byte[len];
             System.Runtime.InteropServices.Marshal.Copy(nativeUtf8, buffer, 0, buffer.Length);
-			System.Runtime.InteropServices.Marshal.FreeHGlobal(nativeUtf8);
             return System.Text.Encoding.UTF8.GetString(buffer);
         }
 		

--- a/uplink.NET/uplink.NET/SWIG-Generated/storj_uplinkPINVOKE.cs
+++ b/uplink.NET/uplink.NET/SWIG-Generated/storj_uplinkPINVOKE.cs
@@ -220,13 +220,17 @@ class storj_uplinkPINVOKE {
             }
         }
 
-	public static string StringFromNativeUtf8(System.IntPtr nativeUtf8)
+        public static string StringFromNativeUtf8(System.IntPtr nativeUtf8)
         {
+            if (nativeUtf8 == global::System.IntPtr.Zero)
+            {
+                return null;
+            }
+
             int len = 0;
             while (System.Runtime.InteropServices.Marshal.ReadByte(nativeUtf8, len) != 0) ++len;
             byte[] buffer = new byte[len];
             System.Runtime.InteropServices.Marshal.Copy(nativeUtf8, buffer, 0, buffer.Length);
-			System.Runtime.InteropServices.Marshal.FreeHGlobal(nativeUtf8);
             return System.Text.Encoding.UTF8.GetString(buffer);
         }
 		


### PR DESCRIPTION
## Summary
- stop freeing native UTF-8 strings returned from storj_uplink so the runtime no longer releases memory it does not own
- regenerate the SWIG marshaler helper to guard null pointers while leaving ownership with the native library

## Testing
- dotnet test uplink.NET/uplink.NET.sln *(fails: dotnet not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_b_68dbcbd4daa883268ec81315d946f1e2