### PR TITLE
Fix Android pipeline NDK API level

### DIFF
--- a/uplink.NET/pipelines/azure-pipelines-build-android.yml
+++ b/uplink.NET/pipelines/azure-pipelines-build-android.yml
@@ -42,8 +42,8 @@ stages:
         export CGO_ENABLED=1
         export GOARCH=arm
         export GOARM=7
-        export CC=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi19-clang
-        export CXX=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi19-clang++
+        export CC=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi21-clang
+        export CXX=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi21-clang++
         go env
         go build -ldflags="-s -w" -tags linux -buildmode c-shared -o libstorj_uplink-armeabi-v7a.so
       displayName: 'Build target armeabi-v7a'
@@ -138,8 +138,8 @@ stages:
         export CGO_ENABLED=1
         export GOARCH=386
         export GOARM=
-        export CC=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android19-clang
-        export CXX=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android19-clang++
+        export CC=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android21-clang
+        export CXX=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android21-clang++
         go env
         go build -ldflags="-s -w" -tags linux -buildmode c-shared -o libstorj_uplink-386.so
       displayName: 'Build target 386'


### PR DESCRIPTION
## Summary
- update the android build pipeline to target API level 21 when selecting the NDK clang toolchains for armv7a and i686
- prevents missing compiler errors with the newer Android NDK distribution

## Testing
- not run (pipeline change only)


------
https://chatgpt.com/codex/tasks/task_b_68dce598cab48326a4dfb9b9dcad90e1